### PR TITLE
fix: include check for nullable types for properties when deserialization is called internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2025-03-19 - 1.0.2
+
+- fix: include check for nullable types for properties when deserialization is called internally [#118](https://github.com/JairusSW/json-as/pull/118)
+
 ## 2025-03-10 - 1.0.1
 
 - docs: add comprehensive performance metrics

--- a/assembly/__tests__/struct.spec.ts
+++ b/assembly/__tests__/struct.spec.ts
@@ -64,6 +64,16 @@ describe("Should deserialize structs with whitespace", () => {
   ).toBe('{"x":3.4,"y":1.2,"z":8.3}');
 });
 
+describe("Should deserialize structs with nullable properties", () => {
+  expect(
+    JSON.stringify(JSON.parse<NullableObj>('{"bar":{"value":"test"}}'))
+  ).toBe('{"bar":{"value":"test"}}');
+
+  expect(
+    JSON.stringify(JSON.parse<NullableObj>('{"bar":null}'))
+  ).toBe('{"bar":null}');
+})
+
 // describe("Should serialize Suite struct", () => {
 
 // });
@@ -107,46 +117,34 @@ class Player {
 
 
 @json
-class ObjWithString {
-  s!: string;
-}
-
-
-@json
 class ObjWithStrangeKey<T> {
   @alias('a\\\t"\x02b`c')
   data!: T;
 }
-
-
-@json
-class ObjectWithStringArray {
-  sa!: string[];
-}
-
 
 @json
 class ObjectWithFloat {
   f!: f64;
 }
 
-
-@json
-class ObjectWithFloatArray {
-  fa!: f64[];
-}
-
-
 @json
 class OmitIf {
   x: i32 = 1;
-
 
   @omitif("this.y == -1")
   y: i32 = -1;
   z: i32 = 1;
 
-
   @omitnull()
   foo: string | null = null;
+}
+
+@json
+class NullableObj {
+  bar: Bar | null = null;
+}
+
+@json
+class Bar {
+  value: string = "";
 }

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -184,42 +184,43 @@ export namespace JSON {
     } else if (isArray<T>()) {
       // @ts-ignore
       return inline.always(deserializeArray<nonnull<T>>(dataPtr, dataPtr + dataSize, changetype<usize>(instantiate<T>())));
-    }
-    let type: nonnull<T> = changetype<nonnull<T>>(0);
-    // @ts-ignore: Defined by transform
-    if (isDefined(type.__DESERIALIZE_CUSTOM)) {
-      const out = changetype<nonnull<T>>(0);
-      // @ts-ignore: Defined by transform
-      if (isDefined(type.__INITIALIZE)) out.__INITIALIZE();
-      // @ts-ignore
-      return out.__DESERIALIZE_CUSTOM(ptrToStr(dataPtr, dataPtr + dataSize));
-      // @ts-ignore: Defined by transform
-    } else if (isDefined(type.__DESERIALIZE)) {
-      const out = __new(offsetof<nonnull<T>>(), idof<nonnull<T>>());
-      // @ts-ignore: Defined by transform
-      if (isDefined(type.__INITIALIZE)) changetype<nonnull<T>>(out).__INITIALIZE();
-      // @ts-ignore
-      return inline.always(deserializeStruct<nonnull<T>>(dataPtr, dataPtr + dataSize, out));
-    } else if (type instanceof Map) {
-      // @ts-ignore
-      return inline.always(deserializeMap<nonnull<T>>(dataPtr, dataPtr + dataSize, 0));
-    } else if (type instanceof Date) {
-      // @ts-ignore
-      return deserializeDate(dataPtr, dataPtr + dataSize);
-    } else if (type instanceof JSON.Raw) {
-      // @ts-ignore: type
-      return deserializeRaw(dataPtr, dataPtr + dataSize);
-    } else if (type instanceof JSON.Value) {
-      // @ts-ignore
-      return inline.always(deserializeArbitrary(dataPtr, dataPtr + dataSize, 0));
-    } else if (type instanceof JSON.Obj) {
-      // @ts-ignore
-      return inline.always(deserializeObject(dataPtr, dataPtr + dataSize, 0));
-    } else if (type instanceof JSON.Box) {
-      // @ts-ignore
-      return new JSON.Box(parseBox(data, changetype<nonnull<T>>(0).value));
     } else {
-      throw new Error(`Could not deserialize data ${data} to type ${nameof<T>()}. Make sure to add the correct decorators to classes.`);
+      let type: nonnull<T> = changetype<nonnull<T>>(0);
+      // @ts-ignore: Defined by transform
+      if (isDefined(type.__DESERIALIZE_CUSTOM)) {
+        const out = changetype<nonnull<T>>(0);
+        // @ts-ignore: Defined by transform
+        if (isDefined(type.__INITIALIZE)) out.__INITIALIZE();
+        // @ts-ignore
+        return out.__DESERIALIZE_CUSTOM(ptrToStr(dataPtr, dataPtr + dataSize));
+        // @ts-ignore: Defined by transform
+      } else if (isDefined(type.__DESERIALIZE)) {
+        const out = __new(offsetof<nonnull<T>>(), idof<nonnull<T>>());
+        // @ts-ignore: Defined by transform
+        if (isDefined(type.__INITIALIZE)) changetype<nonnull<T>>(out).__INITIALIZE();
+        // @ts-ignore
+        return inline.always(deserializeStruct<nonnull<T>>(dataPtr, dataPtr + dataSize, out));
+      } else if (type instanceof Map) {
+        // @ts-ignore
+        return inline.always(deserializeMap<nonnull<T>>(dataPtr, dataPtr + dataSize, 0));
+      } else if (type instanceof Date) {
+        // @ts-ignore
+        return deserializeDate(dataPtr, dataPtr + dataSize);
+      } else if (type instanceof JSON.Raw) {
+        // @ts-ignore: type
+        return deserializeRaw(dataPtr, dataPtr + dataSize);
+      } else if (type instanceof JSON.Value) {
+        // @ts-ignore
+        return inline.always(deserializeArbitrary(dataPtr, dataPtr + dataSize, 0));
+      } else if (type instanceof JSON.Obj) {
+        // @ts-ignore
+        return inline.always(deserializeObject(dataPtr, dataPtr + dataSize, 0));
+      } else if (type instanceof JSON.Box) {
+        // @ts-ignore
+        return new JSON.Box(parseBox(data, changetype<nonnull<T>>(0).value));
+      } else {
+        throw new Error(`Could not deserialize data ${data} to type ${nameof<T>()}. Make sure to add the correct decorators to classes.`);
+      }
     }
   }
 
@@ -581,8 +582,11 @@ export namespace JSON {
       // @ts-ignore: type
       return deserializeString(srcStart, srcEnd, dst);
     } else if (isArray<T>()) {
-      // @ts-ignore
+      // @ts-ignore: type
       return inline.always(deserializeArray<T>(srcStart, srcEnd, dst));
+    } else if (isNullable<T>() && srcEnd - srcStart == 8 && load<u64>(srcStart) == 30399761348886638) {
+      // @ts-ignore
+      return null;
     } else {
       let type: nonnull<T> = changetype<nonnull<T>>(0);
       // @ts-ignore: Defined by transform

--- a/assembly/test.ts
+++ b/assembly/test.ts
@@ -138,3 +138,14 @@ console.log("a11: " + JSON.stringify(a11));
 const a12 = JSON.parse<InnerObj<ObjWithBracketString>>('{"obj":{"data":"hello} world"}}');
 
 console.log("a12: " + JSON.stringify(a12))
+
+
+@json
+class NullableObj {
+  bar: Bar | null = null;
+}
+
+@json
+class Bar {
+  value: string = "";
+}


### PR DESCRIPTION
Consider a two class object structure where the first class optionally references the second via a nullable field:

```ts
@json
class Foo {
  bar: Bar | null = null;
}

@json
class Bar {
  value: string = "";
}
```
Valid inputs should include:

```js
{"bar":{"value":"test"}}
{"bar":null}
```

When passing to `JSON.parse<Foo>(input)`, the first works fine, but the second gives an error:

Expected `'{'` at start of object at position 8 at ~lib/json-as/assembly/deserialize/simple/struct.ts:22:42