### PR TITLE
fix serialization for nested objects with custom serializers + test

### DIFF
--- a/assembly/__tests__/custom.spec.ts
+++ b/assembly/__tests__/custom.spec.ts
@@ -32,6 +32,14 @@ class Point {
   }
 }
 
+@json
+export class ObjectWithCustom {
+  value: Point = new Point(0, 0)
+  constructor(value: Point) {
+    this.value = value
+  }
+}
+
 describe("Should serialize using custom serializers", () => {
   expect(JSON.stringify<Point>(new Point(1, 2))).toBe("(1.0,2.0)");
 });
@@ -40,4 +48,8 @@ describe("Should deserialize using custom deserializers", () => {
   const p1 = JSON.parse<Point>("(1.0,2.0)");
   expect(p1.x.toString()).toBe("1.0");
   expect(p1.y.toString()).toBe("2.0");
+});
+
+describe("Should serialize and deserialize using nested custom serializers", () => {
+  expect(JSON.stringify<ObjectWithCustom>(new ObjectWithCustom(new Point(1, 2)))).toBe(`{"value":(1.0,2.0)}`);
 });

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -552,7 +552,7 @@ export namespace JSON {
       // @ts-ignore: Supplied by transform
     } else if (isDefined(src.__SERIALIZE_CUSTOM)) {
       // @ts-ignore
-      return src.__SERIALIZE_CUSTOM(changetype<usize>(src));
+      return src.__SERIALIZE_CUSTOM();
       // @ts-ignore: Supplied by transform
     } else if (isDefined(src.__SERIALIZE)) {
       // @ts-ignore


### PR DESCRIPTION
Just updating the code with your latest changes, where it was missed, and adding a test.

```
ERROR TS2554: Expected 0 arguments, but got 1.
     :
 555 │ return src.__SERIALIZE_CUSTOM(changetype<usize>(src));
     │        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     └─ in ~lib/json-as/assembly/index.ts(555,14)

FAILURE 1 compile error(s)
```
