### PR TITLE
Tests for deserialization and serialization of objects in namespaces.

### DIFF
--- a/assembly/__tests__/namespace.spec.ts
+++ b/assembly/__tests__/namespace.spec.ts
@@ -1,0 +1,59 @@
+import { JSON } from "..";
+import { describe, expect } from "./lib";
+
+describe("Should serialize namespaced derived structs", () => {
+  const obj: Namespace.DerivedObject = { a: "foo", b: "bar" };
+  expect(JSON.stringify(obj)).toBe(`{"a":"foo","b":"bar"}`);
+});
+
+describe("Should serialize namespaced derived structs with nested object", () => {
+  const bar: Namespace.Bar = { value: "baz" }
+  const obj: Namespace.DerivedObjectWithNestedObject = { a: "foo", b: "bar", c: bar};
+  expect(JSON.stringify(obj)).toBe(`{"a":"foo","b":"bar","c":{"value":"baz"}}`);
+});
+
+describe("Should deserialize namespaced object with alias property", () => {
+  expect(JSON.stringify(JSON.parse<Namespace.ObjectWithAliasProperty>(`{"a":"foo","value":42}`))).toBe(`{"a":"foo","value":42}`);
+});
+
+describe("Should deserialize namespaced derived structs", () => {
+  expect(JSON.stringify(JSON.parse<Namespace.DerivedObject>(`{"a":"foo","b":"bar"}`))).toBe(`{"a":"foo","b":"bar"}`);
+  expect(JSON.stringify(JSON.parse<Namespace.DerivedObject>(`{"b":"bar","a":"foo"}`))).toBe(`{"a":"foo","b":"bar"}`);
+});
+
+describe("Should deserialize namespaced derived structs with nested object", () => {
+  expect(JSON.stringify(JSON.parse<Namespace.DerivedObjectWithNestedObject>(`{"a":"foo","b":"bar","c":{"value":"baz"}}`))).toBe(`{"a":"foo","b":"bar","c":{"value":"baz"}}`);
+  expect(JSON.stringify(JSON.parse<Namespace.DerivedObjectWithNestedObject>(`{"c":{"value":"baz"},"a":"foo","b":"bar"}`))).toBe(`{"a":"foo","b":"bar","c":{"value":"baz"}}`);
+});
+
+type NumberAlias = i64;
+
+namespace Namespace {
+
+  @json
+  export class Base {
+    a: string = "";
+  }
+
+  @json
+  export class Bar {
+    value: string = "";
+  }
+
+  @json
+  export class ObjectWithAliasProperty {
+		a: string = "";
+    value: NumberAlias = 0;
+  }
+
+  @json
+  export class DerivedObject extends Base {
+    b: string = "";
+  }
+
+  @json
+  export class DerivedObjectWithNestedObject extends Base {
+    b: string = "";
+    c: Bar = new Bar();
+  }
+}

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,24 +4,28 @@ mkdir -p ./build
 
 for file in ./assembly/__tests__/*.spec.ts; do
   filename=$(basename -- "$file")
-  output="./build/${filename%.ts}.wasm"
+  if [ -z "$1" ] || [ "$1" = "$filename" ]; then
+    output="./build/${filename%.ts}.wasm"
 
-  start_time=$(date +%s%3N)
-  npx asc "$file" --transform ./transform -o "$output" --enable simd --config ./node_modules/@assemblyscript/wasi-shim/asconfig.json --disableWarning 226 || { echo "Tests failed"; exit 1; }
-  end_time=$(date +%s%3N) 
+    start_time=$(date +%s%3N)
+    npx asc "$file" --transform ./transform -o "$output" --enable simd --config ./node_modules/@assemblyscript/wasi-shim/asconfig.json --disableWarning 226 || { echo "Tests failed"; exit 1; }
+    end_time=$(date +%s%3N)
 
-  build_time=$((end_time - start_time))
+    build_time=$((end_time - start_time))
 
-  if [ "$build_time" -ge 60000 ]; then
-    formatted_time="$(bc <<< "scale=2; $build_time/60000")m"
-  elif [ "$build_time" -ge 1000 ]; then
-    formatted_time="$(bc <<< "scale=2; $build_time/1000")s"
+    if [ "$build_time" -ge 60000 ]; then
+      formatted_time="$(bc <<< "scale=2; $build_time/60000")m"
+    elif [ "$build_time" -ge 1000 ]; then
+      formatted_time="$(bc <<< "scale=2; $build_time/1000")s"
+    else
+      formatted_time="${build_time}ms"
+    fi
+
+    echo " -> $filename (built in $formatted_time)"
+    wasmtime "$output" || { echo "Tests failed"; exit 1; }
   else
-    formatted_time="${build_time}ms"
+    echo " -> $filename (skipped)"
   fi
-
-  echo " -> $filename (built in $formatted_time)"
-  wasmtime "$output" || { echo "Tests failed"; exit 1; }
 done
 
 echo "All tests passed"


### PR DESCRIPTION
The PR adds tests to show a bug when deserializing into objects defined a namespace.
The tests will work if `Namespace` is removed.

The PR also includes an update to  _run-test.sh_ to allow an argument to run a specific test:

```bash
./run-tests.sh namespace.spec.ts
```